### PR TITLE
Update to Swift 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ branches:
   only:
   - master
 
-osx_image: xcode7
+osx_image: xcode7.3
 
 xcode_project: Toast-Swift.xcodeproj
 xcode_scheme: Toast-Swift
-xcode_sdk: iphonesimulator9.0
+xcode_sdk: iphonesimulator9.3

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -104,7 +104,7 @@ extension ViewController {
                     let tapToDismissSwitch = UISwitch()
                     tapToDismissSwitch.onTintColor = UIColor.blueColor()
                     tapToDismissSwitch.on = ToastManager.shared.tapToDismissEnabled
-                    tapToDismissSwitch.addTarget(self, action: "handleTapToDismissToggled", forControlEvents: .ValueChanged)
+                    tapToDismissSwitch.addTarget(self, action: #selector(ViewController.handleTapToDismissToggled), forControlEvents: .ValueChanged)
                     cell?.accessoryView = tapToDismissSwitch
                     cell?.selectionStyle = .None
                     cell?.textLabel?.font = UIFont.systemFontOfSize(16.0)
@@ -116,7 +116,7 @@ extension ViewController {
                     let queueSwitch = UISwitch()
                     queueSwitch.onTintColor = UIColor.blueColor()
                     queueSwitch.on = ToastManager.shared.queueEnabled
-                    queueSwitch.addTarget(self, action: "handleQueueToggled", forControlEvents: .ValueChanged)
+                    queueSwitch.addTarget(self, action: #selector(ViewController.handleQueueToggled), forControlEvents: .ValueChanged)
                     cell?.accessoryView = queueSwitch
                     cell?.selectionStyle = .None
                     cell?.textLabel?.font = UIFont.systemFontOfSize(16.0)

--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -363,7 +363,7 @@ extension UIView {
         toast.alpha = 0.0
         
         if ToastManager.shared.tapToDismissEnabled {
-            let recognizer = UITapGestureRecognizer(target: self, action: "handleToastTapped:")
+            let recognizer = UITapGestureRecognizer(target: self, action: #selector(UIView.handleToastTapped(_:)))
             toast.addGestureRecognizer(recognizer)
             toast.userInteractionEnabled = true
             toast.exclusiveTouch = true
@@ -375,8 +375,8 @@ extension UIView {
         
         UIView.animateWithDuration(ToastManager.shared.style.fadeDuration, delay: 0.0, options: [.CurveEaseOut, .AllowUserInteraction], animations: { () -> Void in
             toast.alpha = 1.0
-        }) { (Bool finished) -> Void in
-            let timer = NSTimer(timeInterval: duration, target: self, selector: "toastTimerDidFinish:", userInfo: toast, repeats: false)
+        }) { (finished) -> Void in
+            let timer = NSTimer(timeInterval: duration, target: self, selector: #selector(UIView.toastTimerDidFinish(_:)), userInfo: toast, repeats: false)
             NSRunLoop.mainRunLoop().addTimer(timer, forMode: NSRunLoopCommonModes)
             objc_setAssociatedObject(toast, &ToastKeys.Timer, timer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }


### PR DESCRIPTION
It fixes:
- Error: "Closure cannot have keyword arguments"
- Warnings: "Use of string literal for Objective-C selectors is deprecated; use '#selector' instead"