### PR TITLE
Fixing compile error: Closure cannot have keyword arguments

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -375,7 +375,7 @@ public extension UIView {
         
         UIView.animateWithDuration(ToastManager.shared.style.fadeDuration, delay: 0.0, options: [.CurveEaseOut, .AllowUserInteraction], animations: { () -> Void in
             toast.alpha = 1.0
-        }) { (Bool finished) -> Void in
+        }) { (finished: Bool) -> Void in
             let timer = NSTimer(timeInterval: duration, target: self, selector: "toastTimerDidFinish:", userInfo: toast, repeats: false)
             NSRunLoop.mainRunLoop().addTimer(timer, forMode: NSRunLoopCommonModes)
             objc_setAssociatedObject(toast, &ToastKeys.Timer, timer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
I'm using the new Xcode 7.3