### PR TITLE
Change from var to let when creating ToastStyle object in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ But wait, there's more!
 ---------
 ```swift
 // create a new style
-var style = ToastStyle()
+let style = ToastStyle()
 
 // this is just one of many style options
 style.messageColor = UIColor.blueColor()


### PR DESCRIPTION
The variable `style` is not changed so it should be defined using `let` statement instead of `var`.