### PR TITLE
Fix#11 messageLabel not honouring maxWidthPercentage

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -506,7 +506,9 @@ public extension UIView {
             let maxMessageSize = CGSize(width: (self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, height: self.bounds.size.height * style.maxHeightPercentage)
             let messageSize = messageLabel?.sizeThatFits(maxMessageSize)
             if let messageSize = messageSize {
-                messageLabel?.frame = CGRect(x: 0.0, y: 0.0, width: messageSize.width, height: messageSize.height)
+                let actualWidth = min(messageSize.width, maxMessageSize.width)
+                let actualHeight = min(messageSize.height, maxMessageSize.height)
+                messageLabel?.frame = CGRect(x: 0.0, y: 0.0, width: actualWidth, height: actualHeight)
             }
         }
   


### PR DESCRIPTION
Fix #11 
The size that `sizeThatFits` return is not reliable, so it's better to min the returned value with the `maxMessageSize` 