### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ But wait, there's more!
 ---------
 ```swift
 // create a new style
-let style = ToastStyle()
+let style = ToastManager.shared.style
 
 // this is just one of many style options
 style.messageColor = UIColor.blueColor()


### PR DESCRIPTION
Since the accessibility to the constructor was removed, it should be reflected in the `readme` of the project.