### PR TITLE
fix title and message alignment not working.

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -538,11 +538,13 @@ public extension UIView {
         wrapperView.frame = CGRect(x: 0.0, y: 0.0, width: wrapperWidth, height: wrapperHeight)
         
         if let titleLabel = titleLabel {
+            titleRect.size.width = longerWidth
             titleLabel.frame = titleRect
             wrapperView.addSubview(titleLabel)
         }
         
         if let messageLabel = messageLabel {
+            messageRect.size.width = longerWidth
             messageLabel.frame = messageRect
             wrapperView.addSubview(messageLabel)
         }


### PR DESCRIPTION
When title and message alignment is set, small width side is left-justified.
I fixed it.

```swift
var style = ToastStyle()
style.titleAlignment = .center
style.messageAlignment = .center
self.navigationController?.view.makeToast("This is a piece of toast with a title", duration: 2.0, position: .top, title: "Toast Title", image: nil, style: style, completion: nil)
```

|before|after|
|-|-|
|![simulator screen shot 2017 06 01 17 04 08](https://cloud.githubusercontent.com/assets/3666836/26671047/14837678-46ef-11e7-9deb-8bffa2f4e181.png)|![simulator screen shot 2017 06 01 17 03 32](https://cloud.githubusercontent.com/assets/3666836/26671050/19607f9c-46ef-11e7-98d6-6d1cbe7b39b8.png)|