### PR TITLE
Fix .center alignement 

### DIFF
--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -171,7 +171,7 @@ extension ViewController {
             // Centering a short label (as title or message) was not possible before, works correctly now.
             style.titleAlignment = .center
             style.messageAlignment = .center
-            self.navigationController?.view.makeToast("This is a piece of toast with a title", duration: 2.0, position: .top, title: "Toast Title", image: nil, style: style
+            self.navigationController?.view.makeToast("This is a piece of toast with a title", duration: 2.0, position: .top, title: "Toast Title", image: nil, style: style)
         case 3:
             // Make toast with an image
             self.navigationController?.view.makeToast("This is a piece of toast with an image", duration: 2.0, position: .center, title: nil, image: UIImage(named: "toast.png"))

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -167,7 +167,11 @@ extension ViewController {
             self.navigationController?.view.makeToast("This is a piece of toast on top for 3 seconds", duration: 3.0, position: .top)
         case 2:
             // Make toast with a title
-            self.navigationController?.view.makeToast("This is a piece of toast with a title", duration: 2.0, position: .top, title: "Toast Title", image: nil)
+            var style = ToastStyle()
+            // Centering a short label (as title or message) was not possible before, works correctly now.
+            style.titleAlignment = .center
+            style.messageAlignment = .center
+            self.navigationController?.view.makeToast("This is a piece of toast with a title", duration: 2.0, position: .top, title: "Toast Title", image: nil, style: style
         case 3:
             // Make toast with an image
             self.navigationController?.view.makeToast("This is a piece of toast with an image", duration: 2.0, position: .center, title: nil, image: UIImage(named: "toast.png"))

--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -408,7 +408,8 @@ public extension UIView {
             let maxTitleSize = CGSize(width: (self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, height: self.bounds.size.height * style.maxHeightPercentage)
             let titleSize = titleLabel?.sizeThatFits(maxTitleSize)
             if let titleSize = titleSize {
-                titleLabel?.frame = CGRect(x: 0.0, y: 0.0, width: titleSize.width, height: titleSize.height)
+                let actualHeight = min(titleSize.height, maxTitleSize.height)
+                titleLabel?.frame = CGRect(x: 0.0, y: 0.0, width: maxTitleSize.width, height: actualHeight)     
             }
         }
         
@@ -425,9 +426,8 @@ public extension UIView {
             let maxMessageSize = CGSize(width: (self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, height: self.bounds.size.height * style.maxHeightPercentage)
             let messageSize = messageLabel?.sizeThatFits(maxMessageSize)
             if let messageSize = messageSize {
-                let actualWidth = min(messageSize.width, maxMessageSize.width)
                 let actualHeight = min(messageSize.height, maxMessageSize.height)
-                messageLabel?.frame = CGRect(x: 0.0, y: 0.0, width: actualWidth, height: actualHeight)
+                messageLabel?.frame = CGRect(x: 0.0, y: 0.0, width: maxMessageSize.width, height: actualHeight)
             }
         }
   


### PR DESCRIPTION
I'm not sure if this was known behaviour but using .center alignement and a short title didn't actually center the title.

The issue was that the width of the title label was equal to the width of the string so that .center alignement wouldn't have any effect. 

I modified the code to make the width of the title and message labels equal to the width of the toast (minus maxHeightPercentage etc...). This allows them to be correctly centered when using titleAlignment = .center and messageAlignment = .center. 