### PR TITLE
Added ToastStyle.tintColor to apply a tint to the imageView

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -77,7 +77,7 @@ extension ViewController {
         if section == 0 {
             return 2
         } else {
-            return 11
+            return 12
         }
     }
     
@@ -144,11 +144,12 @@ extension ViewController {
             case 3: cell.textLabel?.text = "Make toast with an image"
             case 4: cell.textLabel?.text = "Make toast with a title, image, and completion closure"
             case 5: cell.textLabel?.text = "Make toast with a custom style"
-            case 6: cell.textLabel?.text = "Show a custom view as toast"
-            case 7: cell.textLabel?.text = "Show an image as toast at point\n(110, 110)"
-            case 8: cell.textLabel?.text = showingActivity ? "Hide toast activity" : "Show toast activity"
-            case 9: cell.textLabel?.text = "Hide toast"
-            case 10: cell.textLabel?.text = "Hide all toasts"
+            case 6: cell.textLabel?.text = "Make toast with an image and a tint"
+            case 7: cell.textLabel?.text = "Show a custom view as toast"
+            case 8: cell.textLabel?.text = "Show an image as toast at point\n(110, 110)"
+            case 9: cell.textLabel?.text = showingActivity ? "Hide toast activity" : "Show toast activity"
+            case 10: cell.textLabel?.text = "Hide toast"
+            case 11: cell.textLabel?.text = "Hide all toasts"
             default: cell.textLabel?.text = nil
             }
             
@@ -193,16 +194,21 @@ extension ViewController {
             style.backgroundColor = UIColor.yellow
             self.navigationController?.view.makeToast("This is a piece of toast with a custom style", duration: 3.0, position: .bottom, style: style)
         case 6:
+            // Make toast with an image and a tintColor
+            var style = ToastStyle()
+            style.tintColor = UIColor.green
+            self.navigationController?.view.makeToast("This is a piece of toast with an image and a tint", duration: 3.0, position: .center, image: UIImage(named: "toast.png"), style: style)
+        case 7:
             // Show a custom view as toast
             let customView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 80.0, height: 400.0))
             customView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin]
             customView.backgroundColor = .lightBlue
             self.navigationController?.view.showToast(customView, duration: 2.0, position: .center)
-        case 7:
+        case 8:
             // Show an image view as toast, on center at point (110,110)
             let toastView = UIImageView(image: UIImage(named: "toast.png"))
             self.navigationController?.view.showToast(toastView, duration: 2.0, point: CGPoint(x: 110.0, y: 110.0))
-        case 8:
+        case 9:
             // Make toast activity
             if !showingActivity {
                 self.navigationController?.view.makeToastActivity(.center)
@@ -213,10 +219,10 @@ extension ViewController {
             showingActivity = !showingActivity
             
             tableView.reloadData()
-        case 9:
+        case 10:
             // Hide toast
             self.navigationController?.view.hideToast()
-        case 10:
+        case 11:
             // Hide all toasts
             self.navigationController?.view.hideAllToasts()
         default:

--- a/Toast-Swift.xcodeproj/project.pbxproj
+++ b/Toast-Swift.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				TargetAttributes = {
 					151796E61BE68E4B004BA6E5 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = 87SB87GRTA;
+						DevelopmentTeam = JF7AWS3M92;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -348,11 +348,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 87SB87GRTA;
+				DEVELOPMENT_TEAM = JF7AWS3M92;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -366,11 +366,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 87SB87GRTA;
+				DEVELOPMENT_TEAM = JF7AWS3M92;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -393,7 +393,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift-Framework";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift-Framework";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -417,7 +417,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift-Framework";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift-Framework";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Toast-Swift.xcodeproj/project.pbxproj
+++ b/Toast-Swift.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				TargetAttributes = {
 					151796E61BE68E4B004BA6E5 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = JF7AWS3M92;
+						DevelopmentTeam = 87SB87GRTA;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -348,11 +348,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = JF7AWS3M92;
+				DEVELOPMENT_TEAM = 87SB87GRTA;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -366,11 +366,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = JF7AWS3M92;
+				DEVELOPMENT_TEAM = 87SB87GRTA;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -393,7 +393,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift-Framework";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift-Framework";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -417,7 +417,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.scalessec.Toast-Swift-Framework";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jeansarda.Toast-Swift-Framework";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -434,7 +434,12 @@ public extension UIView {
         }
         
         if let image = image {
-            imageView = UIImageView(image: image)
+            if let imageTint = style.tintColor {
+                imageView = UIImageView(image: image.withRenderingMode(.alwaysTemplate))
+                imageView?.tintColor = imageTint
+            } else {
+                imageView = UIImageView(image: image)
+            }
             imageView?.contentMode = .scaleAspectFit
             imageView?.frame = CGRect(x: style.horizontalPadding, y: style.verticalPadding, width: style.imageSize.width, height: style.imageSize.height)
         }
@@ -682,6 +687,11 @@ public struct ToastStyle {
      Activity indicator color. Default is `.white`.
      */
     public var activityIndicatorColor: UIColor = .white
+    
+    /**
+     Image tint color. Default is `nil`. If set, sets the imageView's renderingMode to `.alwaysTemplate`.
+     */
+    public var tintColor: UIColor? = nil
     
     /**
      Activity background color. Default is `.black` at 80% opacity.


### PR DESCRIPTION
Enables definition of the imageView's `tintColor` as a `ToastStyle` attribute.
`ToastStyle.tintColor` defaults to `nil`. 
If any value other than `nil` is set, the imageView's `renderingMode` is set to `.alwaysTemplate`. 

Inspired by issue [#94](https://github.com/scalessec/Toast-Swift/issues/94)