### PR TITLE
Fixed Swift 4.1 flatMap deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode9.4
 script:
  - xcodebuild -scheme Toast-Swift -sdk iphonesimulator build

--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -219,7 +219,7 @@ public extension UIView {
             clearToastQueue()
         }
         
-        activeToasts.flatMap { $0 as? UIView }
+        activeToasts.compactMap { $0 as? UIView }
                     .forEach { hideToast($0) }
         
         if includeActivity {


### PR DESCRIPTION
Just getting rid of the deprecation warning.