### PR TITLE
Update Toast-Swift.podspec

### DIFF
--- a/Toast-Swift.podspec
+++ b/Toast-Swift.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.framework    = 'QuartzCore'
   s.requires_arc = true
   s.ios.deployment_target = '8.0'
+  s.swift_version= '4.2'
 end


### PR DESCRIPTION
Set swift_version in  Toast-Swift.podspec instead of file .swift_version.
When develop Devolop Pod ,swifit version will be 4.0 and get some error. but set swift_version in  Toast-Swift.podspec instead of file .swift_version wil be ok.