### PR TITLE
wrong size when toast is only title #93

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -505,7 +505,12 @@ public extension UIView {
         let longerWidth = max(titleRect.size.width, messageRect.size.width)
         let longerX = max(titleRect.origin.x, messageRect.origin.x)
         let wrapperWidth = max((imageRect.size.width + (style.horizontalPadding * 2.0)), (longerX + longerWidth + style.horizontalPadding))
-        let wrapperHeight = max((messageRect.origin.y + messageRect.size.height + style.verticalPadding), (imageRect.size.height + (style.verticalPadding * 2.0)))
+        
+        // if message is empty no need padding.
+        let messagePadding = message?.isEmpty ?? true ? 0 : style.verticalPadding
+        
+        let wrapperHeight = max((messageRect.origin.y + messageRect.size.height + messagePadding), (imageRect.size.height + (style.verticalPadding * 2.0)))
+
         
         wrapperView.frame = CGRect(x: 0.0, y: 0.0, width: wrapperWidth, height: wrapperHeight)
         


### PR DESCRIPTION
Bug #93:
When you pass empty message string and only title. there is unneeded space at the bottom.

Fix:
- When message is empty no need to add padding for message.