### PR TITLE
Add rotate support to ToastStyle

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -508,7 +508,8 @@ public extension UIView {
         let wrapperHeight = max((messageRect.origin.y + messageRect.size.height + style.verticalPadding), (imageRect.size.height + (style.verticalPadding * 2.0)))
         
         wrapperView.frame = CGRect(x: 0.0, y: 0.0, width: wrapperWidth, height: wrapperHeight)
-        
+        wrapperView.transform = CGAffineTransform(rotationAngle: style.rotationAngle)   
+     
         if let titleLabel = titleLabel {
             titleRect.size.width = longerWidth
             titleLabel.frame = titleRect
@@ -688,6 +689,10 @@ public struct ToastStyle {
      */
     public var activityBackgroundColor: UIColor = UIColor.black.withAlphaComponent(0.8)
     
+    /**
+     Rotation angle to tranform the toast view with, in radians. Default is 0
+     */
+    public var rotationAngle: CGFloat = 0.0
 }
 
 // MARK: - Toast Manager


### PR DESCRIPTION
This is something we required within our project as we have a Camera Preview view with a locked orientation where we manually rotate view elements to match the current device orientation. It's only really useful when `position` is `.center`, as rotating with `.top` & `.bottom` will probably make the toast view protrude the screen edge.

If you want i can look into adjusting the position for `.top` & `.bottom` when `rotationAngle` is used so this doesn't occur.