### PR TITLE
Fix Timer race condition

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -347,13 +347,16 @@ public extension UIView {
         
         activeToasts.add(toast)
         self.addSubview(toast)
-        
+
+        let timer = Timer(timeInterval: duration, target: self, selector: #selector(UIView.toastTimerDidFinish(_:)), userInfo: toast, repeats: false)
+        objc_setAssociatedObject(toast, &ToastKeys.timer, timer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
         UIView.animate(withDuration: ToastManager.shared.style.fadeDuration, delay: 0.0, options: [.curveEaseOut, .allowUserInteraction], animations: {
             toast.alpha = 1.0
         }) { _ in
-            let timer = Timer(timeInterval: duration, target: self, selector: #selector(UIView.toastTimerDidFinish(_:)), userInfo: toast, repeats: false)
-            RunLoop.main.add(timer, forMode: .common)
-            objc_setAssociatedObject(toast, &ToastKeys.timer, timer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            if let timer = objc_getAssociatedObject(toast, &ToastKeys.timer) as? Timer {
+              RunLoop.main.add(timer, forMode: .common)
+            }
         }
     }
     


### PR DESCRIPTION
Hey while using Toast we noticed our animation loading view that we add to toast was not being released and was being held onto by an instance of a timer. 

After some debugging it seems like there's an edge case where we call `hideToast` which attempts to invalidate the timer before the Timer has even been created for that view. This is because the timer only gets created in the async completion block in `showToast`.  If the `duration` passed in to `showToast` is relatively big, then the toast UIView will be removed from the hierarchy but the Timer will still be created asynchronously causing a memory spike.     