### PR TITLE
hide all toasts from pushed view controllers

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -77,7 +77,7 @@ extension ViewController {
         if section == 0 {
             return 2
         } else {
-            return 11
+            return 12
         }
     }
     
@@ -149,6 +149,7 @@ extension ViewController {
             case 8: cell.textLabel?.text = showingActivity ? "Hide toast activity" : "Show toast activity"
             case 9: cell.textLabel?.text = "Hide toast"
             case 10: cell.textLabel?.text = "Hide all toasts"
+            case 11: cell.textLabel?.text = "Hide toasts from all pushed view controllers test"
             default: cell.textLabel?.text = nil
             }
             
@@ -219,8 +220,33 @@ extension ViewController {
         case 10:
             // Hide all toasts
             self.navigationController?.view.hideAllToasts()
+        case 11:
+            // Display a toast view on TableView View Controller
+            self.navigationController?.view.makeToast("Toast on TableView View Controller", duration: .infinity, position: .top)
+            
+            // Push another View Controller after 3 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: {
+                self.navigationController?.pushViewController(ViewControllerToPush(), animated: true)
+            })
+            
         default:
             break
         }
     }
+}
+
+class ViewControllerToPush : UIViewController{
+    
+       // MARK: - View Lifecycle
+
+       override func viewDidLoad() {
+           super.viewDidLoad()
+            // Display a toast view on ViewControllerToPush
+           self.navigationController?.view.makeToast("Toast on Pushed View Controller", duration: .infinity, position: .bottom)
+        
+            // Hide all toasts from pushed view conrollers which are on navigation stack after 3 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: {
+                self.navigationController?.view.hideToastsFromAllPushedVCs()
+            })
+       }
 }

--- a/Toast-Swift.xcodeproj/xcshareddata/xcschemes/Toast-Swift.xcscheme
+++ b/Toast-Swift.xcodeproj/xcshareddata/xcschemes/Toast-Swift.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Toast-Swift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Toast-Swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -236,6 +236,38 @@ public extension UIView {
         queue.removeAllObjects()
     }
     
+    /**
+     Hides all toast views from the pushed view controllers which are on navigation stack.
+     This method can be useful to hide  if there is toast views attached to view controllers which are on the navigation stack.
+    */
+    func hideToastsFromAllPushedVCs(){
+        self.getTopController()?.view.hideAllToasts()
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        if let controller = appDelegate.window?.rootViewController?.presentedViewController{
+            //viewcontroller even after presented
+            controller.view.hideAllToasts()
+        } else if let controllers = appDelegate.window?.rootViewController?.children {
+            // Array of all viewcontroller after push
+            for vc in controllers{
+                vc.view.hideAllToasts()
+            }
+        }
+    }
+    
+    func getTopController() -> UIViewController?{
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        
+        if var topController = keyWindow?.rootViewController {
+            while let presentedViewController = topController.presentedViewController {
+                topController = presentedViewController
+            }
+            // topController should now be your topmost view controller
+            return topController
+        }else{
+            return nil
+        }
+    }
+    
     // MARK: - Activity Methods
     
     /**


### PR DESCRIPTION
I have faced the case when there is multiple pushed view controllers and there is toast views attached to them, dismissing all toast views might be easy by calling only one method.

Added hideToastsFromAllPushedVCs() method along with getTopController() method into Toast class. Also added test scenario by inserting one more row into table view.