### PR TITLE
Update Toast-Swift.podspec to iOS 9 minimum deployment

### DIFF
--- a/Toast-Swift.podspec
+++ b/Toast-Swift.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Toast'   
   s.framework    = 'QuartzCore'
   s.requires_arc = true
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.swift_version= '5.0'
 end


### PR DESCRIPTION
<img width="466" alt="Screen Shot 2020-11-08 at 10 34 03 PM" src="https://user-images.githubusercontent.com/1163880/98497625-84574680-2212-11eb-93f6-ead900e99d3c.png">

Resolves a warning in Xcode 12