### PR TITLE
Fix can't associate an object with a String key.

### DIFF
--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -42,13 +42,13 @@ public extension UIView {
      Keys used for associated objects.
      */
     private struct ToastKeys {
-        static var timer        = "com.toast-swift.timer"
-        static var duration     = "com.toast-swift.duration"
-        static var point        = "com.toast-swift.point"
-        static var completion   = "com.toast-swift.completion"
-        static var activeToasts = "com.toast-swift.activeToasts"
-        static var activityView = "com.toast-swift.activityView"
-        static var queue        = "com.toast-swift.queue"
+        static var timer: Int        = 0
+        static var duration: Int     = 0
+        static var point: Int        = 0
+        static var completion: Int   = 0
+        static var activeToasts: Int = 0
+        static var activityView: Int = 0
+        static var queue: Int        = 0
     }
     
     /**


### PR DESCRIPTION
Hi, @scalessec 
There is an error associating an object in Xcode 15, Swift 5.9.
The code: `objc_getAssociatedObject(self, &ToastKeys.activeToasts)` will always return nil with String keys.
![image](https://github.com/scalessec/Toast-Swift/assets/37807381/8ffa9b6d-f5b9-41ee-99f1-a33fb57865cc)


- swift-evolution: [Associated object String keys](https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#associated-object-string-keys)
- This solution is from [IQKeyBoardManager](https://github.com/hackiftekhar/IQKeyboardManager/blob/c878b6cec31ff1dbf1b8a0eef36d9a52f833fb03/IQKeyboardManagerSwift/IQToolbar/IQUIView%2BIQKeyboardToolbar.swift#L188C1-L192C6)
  
![image](https://github.com/scalessec/Toast-Swift/assets/37807381/192b2278-7afa-4909-a2fb-6738f5f6dde0)


related issues: 
- #204 