### PR TITLE
Alignment of message for toast with an image and no title

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -143,12 +143,13 @@ extension ViewController {
             case 2: cell.textLabel?.text = "Make toast with a title"
             case 3: cell.textLabel?.text = "Make toast with an image"
             case 4: cell.textLabel?.text = "Make toast with a title, image, and completion closure"
-            case 5: cell.textLabel?.text = "Make toast with a custom style"
-            case 6: cell.textLabel?.text = "Show a custom view as toast"
-            case 7: cell.textLabel?.text = "Show an image as toast at point\n(110, 110)"
-            case 8: cell.textLabel?.text = showingActivity ? "Hide toast activity" : "Show toast activity"
-            case 9: cell.textLabel?.text = "Hide toast"
-            case 10: cell.textLabel?.text = "Hide all toasts"
+            case 5: cell.textLabel?.text = "Make toast with an image, and completion closure"
+            case 6: cell.textLabel?.text = "Make toast with a custom style"
+            case 7: cell.textLabel?.text = "Show a custom view as toast"
+            case 8: cell.textLabel?.text = "Show an image as toast at point\n(110, 110)"
+            case 9: cell.textLabel?.text = showingActivity ? "Hide toast activity" : "Show toast activity"
+            case 10: cell.textLabel?.text = "Hide toast"
+            case 11: cell.textLabel?.text = "Hide all toasts"
             default: cell.textLabel?.text = nil
             }
             
@@ -174,7 +175,7 @@ extension ViewController {
             self.navigationController?.view.makeToast("This is a piece of toast with a title", duration: 2.0, position: .top, title: "Toast Title", image: nil)
         case 3:
             // Make toast with an image
-            self.navigationController?.view.makeToast("This is a piece of toast with an image", duration: 2.0, position: .center, title: nil, image: UIImage(named: "toast.png"))
+            self.navigationController?.view.makeToast("This is a piece of toast with an image and long title", duration: 2.0, position: .center, title: nil, image: UIImage(named: "toast.png"))
         case 4:
             // Make toast with an image, title, and completion closure
             self.navigationController?.view.makeToast("This is a piece of toast with a title, image, and completion closure", duration: 2.0, position: .bottom, title: "Toast Title", image: UIImage(named: "toast.png")) { didTap in
@@ -185,6 +186,15 @@ extension ViewController {
                 }
             }
         case 5:
+            // Make toast with an image, and completion closure
+            self.navigationController?.view.makeToast("This is a piece of toast with an image, and completion closure", duration: 2.0, position: .bottom, image: UIImage(named: "toast.png")) { didTap in
+                if didTap {
+                    print("completion from tap")
+                } else {
+                    print("completion without tap")
+                }
+            }
+        case 6:
             // Make toast with a custom style
             var style = ToastStyle()
             style.messageFont = UIFont(name: "Zapfino", size: 14.0)!
@@ -192,17 +202,17 @@ extension ViewController {
             style.messageAlignment = .center
             style.backgroundColor = UIColor.yellow
             self.navigationController?.view.makeToast("This is a piece of toast with a custom style", duration: 3.0, position: .bottom, style: style)
-        case 6:
+        case 7:
             // Show a custom view as toast
             let customView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 80.0, height: 400.0))
             customView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin]
             customView.backgroundColor = .lightBlue
             self.navigationController?.view.showToast(customView, duration: 2.0, position: .center)
-        case 7:
+        case 8:
             // Show an image view as toast, on center at point (110,110)
             let toastView = UIImageView(image: UIImage(named: "toast.png"))
             self.navigationController?.view.showToast(toastView, duration: 2.0, point: CGPoint(x: 110.0, y: 110.0))
-        case 8:
+        case 9:
             // Make toast activity
             if !showingActivity {
                 self.navigationController?.view.makeToastActivity(.center)
@@ -213,10 +223,10 @@ extension ViewController {
             showingActivity.toggle()
             
             tableView.reloadData()
-        case 9:
+        case 10:
             // Hide toast
             self.navigationController?.view.hideToast()
-        case 10:
+        case 11:
             // Hide all toasts
             self.navigationController?.view.hideAllToasts()
         default:

--- a/Toast/Toast.swift
+++ b/Toast/Toast.swift
@@ -533,6 +533,9 @@ public extension UIView {
         if let messageLabel = messageLabel {
             messageRect.size.width = longerWidth
             messageLabel.frame = messageRect
+            if titleLabel == nil {
+                messageLabel.center.y = wrapperView.center.y
+            }
             wrapperView.addSubview(messageLabel)
         }
         


### PR DESCRIPTION
Hello,

I really like this Toast library and while integrating it into one of my projects I've noticed some strange alignment. 
If you set an image and just message **(no titile)** it looks like this:
![before](https://github.com/scalessec/Toast-Swift/assets/2727829/9572bc66-586c-492b-a297-e5b661d52dec)

And will be better IMHO to align like this:
![after](https://github.com/scalessec/Toast-Swift/assets/2727829/171b4607-3405-4607-8e26-ced27e7c04bb)

Thanks! Open for discussion